### PR TITLE
Move the matcher-combinators out of `core` and into `matchers`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :plugins [[lein-midje "3.2.1"]
             [lein-ancient "0.6.14"]]
-  :dependencies [[org.clojure/clojure "1.9.0-RC2"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]]
   :profiles {:dev {:dependencies [[colorize "0.1.1" :exclusions [org.clojure/clojure]]
                                   [org.clojure/test.check "0.9.0"]
                                   [org.clojure/tools.namespace "0.2.11"]

--- a/src/matcher_combinators/matchers.clj
+++ b/src/matcher_combinators/matchers.clj
@@ -1,0 +1,61 @@
+(ns matcher-combinators.matchers
+  (:require [matcher-combinators.core :as core]))
+
+(defn equals-value
+  "Matcher that will match when the given value is exactly the same as the
+  `expected`."
+  [expected]
+  (core/->Value expected))
+
+(defn contains-map
+  "Matcher that will match when the map contains some of the same key/values as
+  the `expected` map."
+  [expected]
+  (core/->ContainsMap expected))
+
+(defn equals-map
+  "Matcher that will match when:
+    1. the keys of the `expected` map are equal to the given map's keys
+    2. the value matchers of `expected` map matches the given map's values"
+  [expected]
+  (assert (map? expected))
+  (core/->EqualsMap expected))
+
+(defn equals-seq
+  "Matcher that will match when the `expected` list's matchers match the given list.
+
+  Similar to midje's `(just expected)`"
+  [expected]
+  (assert (vector? expected))
+  (core/->EqualsSequence expected))
+
+(defn in-any-order
+  "Matcher that will match when the given a list that is the same as the
+  `expected` list but with elements in a different order.
+
+  `select-fn`: optional argument used to anchoring specific substructures to
+               clarify mismatch output
+
+  Similar to Midje's `(just expected :in-any-order)`"
+  ([expected]
+   (core/->InAnyOrder expected))
+  ([select-fn expected]
+   (core/->SelectingInAnyOrder select-fn expected)))
+
+(defn sublist
+  "Matcher that will match when provided a (ordered) prefix of the `expected`
+  list.
+
+  Similar to Midje's `(contains expected)`"
+  [expected]
+  (assert (vector? expected))
+  (core/->SubSeq expected))
+
+(defn subset
+  "Order-agnostic matcher that will match when provided a subset of the
+  `expected` list.
+
+  Similar to Midje's `(contains expected :in-any-order :gaps-ok)`"
+  [expected]
+  (assert (vector? expected))
+  (core/->SubSet expected))

--- a/src/matcher_combinators/parser.clj
+++ b/src/matcher_combinators/parser.clj
@@ -1,5 +1,6 @@
 (ns matcher-combinators.parser
   (:require [matcher-combinators.core :as core]
+            [matcher-combinators.matchers :as matchers]
             [matcher-combinators.model :as model])
   (:import [clojure.lang Keyword Symbol Ratio BigInt IPersistentMap IPersistentVector]
            [java.util UUID Date]
@@ -19,7 +20,7 @@
       [:match actual]
       [:mismatch (model/->FailedPredicate (str this) actual)])))
 
-(mimic-matcher core/equals-value
+(mimic-matcher matchers/equals-value
                Long
                String
                Symbol
@@ -36,5 +37,5 @@
                BigInt
                Character)
 
-(mimic-matcher core/contains-map IPersistentMap)
-(mimic-matcher core/equals-seq IPersistentVector)
+(mimic-matcher matchers/contains-map IPersistentMap)
+(mimic-matcher matchers/equals-seq IPersistentVector)

--- a/test/matcher_combinators/checkers_test.clj
+++ b/test/matcher_combinators/checkers_test.clj
@@ -1,7 +1,8 @@
 (ns matcher-combinators.checkers-test
-  (:require [midje.sweet :as m :refer [fact facts future-fact =>]]
+  (:require [midje.sweet :as midje :refer [fact facts future-fact =>]]
             [matcher-combinators.parser]
             [matcher-combinators.midje :as ch]
+            [matcher-combinators.matchers :as m]
             [matcher-combinators.core :as c]))
 
 (fact "sequence matching"
@@ -12,8 +13,8 @@
   [[[1]]] => (ch/match [[[odd?]]]))
 
 (fact "map matching"
-  {:a {:bb 1} :c 2} => (ch/match (c/equals-map {:a {:bb 1} :c 2}))
-  {:a {:bb 1} :c 2} => (ch/match (c/equals-map {:a {:bb odd?} :c 2})))
+  {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb 1} :c 2}))
+  {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb odd?} :c 2})))
 
 (fact "map embeds"
   {:a {:aa 11 :bb {:aaa 111}} :b 2} => (ch/match {:a {:bb {:aaa 111}}})
@@ -22,7 +23,7 @@
 
 (fact "map in a sequence in a map"
   {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match {:a [{:bb 1} {:cc 2 :dd 3}] :b 4})
-  {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match (c/equals-map {:a [{:bb 1} {:cc 2 :dd 3}] :b 4})))
+  {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match (m/equals-map {:a [{:bb 1} {:cc 2 :dd 3}] :b 4})))
 
 (future-fact "nuanced map in a sequence in a map behavior"
   ;; Should the following 2 tests pass?
@@ -30,77 +31,77 @@
   {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match {:a [{:bb 1} {:cc 2}] :b 4}))
 
 (fact "use midje checkers inside matchers"
-  {:a {:bb 1} :c 2} => (ch/match (c/equals-map {:a {:bb m/anything} :c 2}))
-  {:a {:bb 1} :c 2} => (ch/match (c/equals-map {:a {:bb (m/roughly 1)} :c 2}))
-  {:a {:bb 1} :c 2} => (ch/match {:a {:bb m/anything}})
-  {:a {:bb 1} :c 2} => (ch/match {:a {:bb (m/roughly 1)}}))
+  {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb midje/anything} :c 2}))
+  {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb (midje/roughly 1)} :c 2}))
+  {:a {:bb 1} :c 2} => (ch/match {:a {:bb midje/anything}})
+  {:a {:bb 1} :c 2} => (ch/match {:a {:bb (midje/roughly 1)}}))
 
 (facts "predicates in matchers"
   (fact "you can use a plain predicate inside matchers"
-    {:a {:bb 1} :c 2} => (ch/match (c/equals-map {:a {:bb odd?} :c 2}))
+    {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb odd?} :c 2}))
     {:a {:bb 1} :c 2} => (ch/match {:a {:bb odd?}}))
   (fact "but if you want to check exact functions use `equals-value` which
         works like midje's 'exactly'"
-    {:a {:bb odd?} :c 2} =not=> (ch/match (c/equals-map {:a {:bb odd?} :c 2}))
-    {:a {:bb odd?} :c 2} => (ch/match (c/equals-map {:a {:bb (c/equals-value odd?)} :c 2}))
-    {:a {:bb odd?} :c 2} => (ch/match (c/equals-map {:a {:bb (m/exactly odd?)} :c 2}))))
+    {:a {:bb odd?} :c 2} =not=> (ch/match (m/equals-map {:a {:bb odd?} :c 2}))
+    {:a {:bb odd?} :c 2} => (ch/match (m/equals-map {:a {:bb (m/equals-value odd?)} :c 2}))
+    {:a {:bb odd?} :c 2} => (ch/match (m/equals-map {:a {:bb (midje/exactly odd?)} :c 2}))))
 
 (defrecord Point [x y])
 
 (fact "matching records with maps"
-  (->Point 1 2) => (ch/match (c/equals-map {:x 1 :y 2}))
+  (->Point 1 2) => (ch/match (m/equals-map {:x 1 :y 2}))
   {:a (->Point 1 2) :b 2} => (ch/match {:a (->Point 1 2)})
   {:a (->Point 1 2) :b 2} => (ch/match {:a {:x 1 :y 2}})
   (->Point {:a 1} {:b 2}) => (ch/match {:x {:a 1}})
-  (->Point {:a [1 2]} {:b 2}) => (ch/match {:x {:a (c/in-any-order [2 1])}})
+  (->Point {:a [1 2]} {:b 2}) => (ch/match {:x {:a (m/in-any-order [2 1])}})
   (->Point {:a 1 :c 3} {:b 2}) =not=> (ch/match {:x {:a 1 :c 6}}))
 
 ;; TODO PLM: do we want to allow this?:
 (fact "matching maps with records"
-  {:x 1 :y 2} => (ch/match (c/equals-map (->Point 1 2)))
+  {:x 1 :y 2} => (ch/match (m/equals-map (->Point 1 2)))
   {:a {:x 1 :y 2}} => (ch/match {:a (->Point 1 2)})
-  {:x 1 :y 3} =not=> (ch/match (c/equals-map (->Point 1 2)))
-  {:x 1 :z 2} =not=> (ch/match (c/equals-map (->Point 1 2))))
+  {:x 1 :y 3} =not=> (ch/match (m/equals-map (->Point 1 2)))
+  {:x 1 :z 2} =not=> (ch/match (m/equals-map (->Point 1 2))))
 
 (fact "matching records with records"
-  (->Point 1 2) => (ch/match (c/equals-map (->Point 1 2)))
+  (->Point 1 2) => (ch/match (m/equals-map (->Point 1 2)))
   (->Point 1 2) => (ch/match (->Point 1 2)))
 
 (fact "equals-map doesn't coerce like midje `just`"
-  {:a 1 :b 2} => (m/just [[:a 1] [:b 2]])
-  {:a 1 :b 2} =not=> (ch/match (c/equals-seq [[:a 1] [:b 2]])))
+  {:a 1 :b 2} => (midje/just [[:a 1] [:b 2]])
+  {:a 1 :b 2} =not=> (ch/match (m/equals-seq [[:a 1] [:b 2]])))
 
 (future-fact "dealing with sets"
-  #{3 8 1} => (m/just [odd? 3 even?])
+  #{3 8 1} => (midje/just [odd? 3 even?])
   ;; When would someone write a test like this:
   ;; and how is the best way to write such tests using matcher-combinators?
-  #{3 8 1} =not=> (ch/match (c/equals-seq [(m/as-checker odd?) 3 (m/as-checker even?)])))
+  #{3 8 1} =not=> (ch/match (m/equals-seq [(midje/as-checker odd?) 3 (midje/as-checker even?)])))
 
-(fact [5 1 4 2] => (m/contains [1 2 5] :gaps-ok :in-any-order))
-(fact [5 1 4 2] => (ch/match (c/sublist [5 1]))
-      [5 1 4 2] => (ch/match (c/sublist [5 1 4 2]))
-      [5 1 4 2] =not=> (ch/match (c/sublist [5 1 4 2 6]))
-      [5 1 4 2] =not=> (ch/match (c/sublist [1 5])))
+(fact [5 1 4 2] => (midje/contains [1 2 5] :gaps-ok :in-any-order))
+(fact [5 1 4 2] => (ch/match (m/sublist [5 1]))
+      [5 1 4 2] => (ch/match (m/sublist [5 1 4 2]))
+      [5 1 4 2] =not=> (ch/match (m/sublist [5 1 4 2 6]))
+      [5 1 4 2] =not=> (ch/match (m/sublist [1 5])))
 
-(fact [5 1 4 2] => (ch/match (c/subset [5 1]))
-      [5 1 4 2] => (ch/match (c/subset [1 5]))
-      [5 1 4 2] => (ch/match (c/subset [5 1 4 2]))
-      [5 1 4 2] => (ch/match (c/subset [1 5 2 4]))
-      [5 1 4 2] =not=> (ch/match (c/subset [5 1 4 2 6])))
+(fact [5 1 4 2] => (ch/match (m/subset [5 1]))
+      [5 1 4 2] => (ch/match (m/subset [1 5]))
+      [5 1 4 2] => (ch/match (m/subset [5 1 4 2]))
+      [5 1 4 2] => (ch/match (m/subset [1 5 2 4]))
+      [5 1 4 2] =not=> (ch/match (m/subset [5 1 4 2 6])))
 
 (fact "Find optimal in-any-order matching just like midje"
-  [1 3] => (m/just [odd? 1] :in-any-order)
+  [1 3] => (midje/just [odd? 1] :in-any-order)
 
-  {:a [1 3]} => (ch/match (c/equals-map {:a (c/in-any-order [odd? 1])}))
-  {:a [1 3]} => (ch/match (c/equals-map {:a (c/in-any-order [1 odd?])}))
+  {:a [1 3]} => (ch/match (m/equals-map {:a (m/in-any-order [odd? 1])}))
+  {:a [1 3]} => (ch/match (m/equals-map {:a (m/in-any-order [1 odd?])}))
 
-  {:a [1 3]} => (ch/match (c/equals-map {:a (c/in-any-order [(m/as-checker odd?) 1])}))
-  {:a [1]} =not=> (ch/match (c/equals-map {:a (c/in-any-order [(m/as-checker odd?) 1])}))
-  [1 2] => (ch/match (c/in-any-order [(m/as-checker even?)
-                                      (m/as-checker odd?)])))
+  {:a [1 3]} => (ch/match (m/equals-map {:a (m/in-any-order [(midje/as-checker odd?) 1])}))
+  {:a [1]} =not=> (ch/match (m/equals-map {:a (m/in-any-order [(midje/as-checker odd?) 1])}))
+  [1 2] => (ch/match (m/in-any-order [(midje/as-checker even?)
+                                      (midje/as-checker odd?)])))
 
-(m/unfinished f)
-(let [short-list (ch/match (c/equals-seq [m/anything m/anything m/anything]))]
+(midje/unfinished f)
+(let [short-list (ch/match (m/equals-seq [midje/anything midje/anything midje/anything]))]
   (fact "using matchers on the left side of the arrow"
     (f [1 2 3]) => 1
     (provided

--- a/test/matcher_combinators/core_test.clj
+++ b/test/matcher_combinators/core_test.clj
@@ -1,6 +1,7 @@
 (ns matcher-combinators.core-test
   (:require [midje.sweet :refer :all :exclude [exactly]]
             [matcher-combinators.core :refer :all]
+            [matcher-combinators.matchers :refer :all]
             [matcher-combinators.model :as model]))
 
 (facts "on the leaf values matcher: v"

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -1,5 +1,5 @@
 (ns matcher-combinators.midje-test
-  (:require [midje.sweet :as midje :refer [fact facts future-fact =>]]
+  (:require [midje.sweet :as midje :refer [fact facts =>]]
             [matcher-combinators.midje :as ch]
             [matcher-combinators.matchers :as m]
             [matcher-combinators.core :as c]))
@@ -23,11 +23,6 @@
 (fact "map in a sequence in a map"
   {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match {:a [{:bb 1} {:cc 2 :dd 3}] :b 4})
   {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match (m/equals-map {:a [{:bb 1} {:cc 2 :dd 3}] :b 4})))
-
-(future-fact "nuanced map in a sequence in a map behavior"
-  ;; Should the following 2 tests pass?
-  {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match {:a [{:bb 1} {:cc 2}]})
-  {:a [{:bb 1} {:cc 2 :dd 3}] :b 4} => (ch/match {:a [{:bb 1} {:cc 2}] :b 4}))
 
 (fact "use midje checkers inside matchers"
   {:a {:bb 1} :c 2} => (ch/match (m/equals-map {:a {:bb midje/anything} :c 2}))
@@ -70,11 +65,12 @@
   {:a 1 :b 2} => (midje/just [[:a 1] [:b 2]])
   {:a 1 :b 2} =not=> (ch/match (m/equals-seq [[:a 1] [:b 2]])))
 
-(future-fact "dealing with sets"
-  #{3 8 1} => (midje/just [odd? 3 even?])
-  ;; When would someone write a test like this:
-  ;; and how is the best way to write such tests using matcher-combinators?
-  #{3 8 1} =not=> (ch/match (m/equals-seq [(midje/as-checker odd?) 3 (midje/as-checker even?)])))
+(facts "dealing with sets"
+ (fact "midje set checker example"
+    #{3 8 1} => (midje/just [odd? 3 even?]))
+ (fact "to match sets, you need to turn it into a list"
+  #{3 8 1} =not=> (ch/match (m/equals-seq [(midje/as-checker odd?) 3 (midje/as-checker even?)]))
+  (seq #{3 8 1}) => (ch/match (m/in-any-order [(midje/as-checker odd?) 3 (midje/as-checker even?)]))))
 
 (fact [5 1 4 2] => (midje/contains [1 2 5] :gaps-ok :in-any-order))
 (fact [5 1 4 2] => (ch/match (m/sublist [5 1]))

--- a/test/matcher_combinators/midje_test.clj
+++ b/test/matcher_combinators/midje_test.clj
@@ -1,6 +1,5 @@
-(ns matcher-combinators.checkers-test
+(ns matcher-combinators.midje-test
   (:require [midje.sweet :as midje :refer [fact facts future-fact =>]]
-            [matcher-combinators.parser]
             [matcher-combinators.midje :as ch]
             [matcher-combinators.matchers :as m]
             [matcher-combinators.core :as c]))

--- a/test/matcher_combinators/parser_test.clj
+++ b/test/matcher_combinators/parser_test.clj
@@ -2,7 +2,8 @@
   (:require [midje.sweet :refer :all :exclude [exactly]]
             [midje.experimental :refer [for-all]]
             [matcher-combinators.parser]
-            [matcher-combinators.core :refer :all]
+            [matcher-combinators.matchers :refer :all]
+            [matcher-combinators.core :as core]
             [clojure.test.check.generators :as gen]
             [matcher-combinators.model :as model]))
 
@@ -35,20 +36,20 @@
 (facts "scalar values act as equals-value matchers"
   (for-all [i gen-scalar]
     {:num-tests 50}
-    (match i i) => (match (equals-value i) i))
+    (core/match i i) => (core/match (equals-value i) i))
 
   (for-all [[i j] gen-scalar-pair]
     {:num-tests 50}
-    (match i j) => (match (equals-value i) j)))
+    (core/match i j) => (core/match (equals-value i) j)))
 
 (fact "maps act as equals-map matchers"
   (fact
-    (= (match (equals-map {:a (equals-value 10)}) {:a 10})
-       (match (equals-map {:a 10}) {:a 10}))
+    (= (core/match (equals-map {:a (equals-value 10)}) {:a 10})
+       (core/match (equals-map {:a 10}) {:a 10}))
     => truthy))
 
 (fact "vectors act as equals-seq matchers"
   (fact
-    (= (match (equals-seq [10]) [10])
-       (match (equals-seq [(equals-value 10)]) [10]))
+    (= (core/match (equals-seq [10]) [10])
+       (core/match (equals-seq [(equals-value 10)]) [10]))
     => truthy))

--- a/test/matcher_combinators/printer_test.clj
+++ b/test/matcher_combinators/printer_test.clj
@@ -3,7 +3,6 @@
             [midje.experimental :refer [for-all]]
             [matcher-combinators.printer :as printer]
             [matcher-combinators.model :as model]
-            [matcher-combinators.core :as core]
             [clojure.test.check.generators :as gen]
             [colorize.core :as colorize]
             [clojure.pprint :as pprint]))

--- a/test/matcher_combinators/test_test.clj
+++ b/test/matcher_combinators/test_test.clj
@@ -1,6 +1,7 @@
 (ns matcher-combinators.test-test
   (:require [matcher-combinators.test]
             [matcher-combinators.core :as core]
+            [matcher-combinators.matchers :as m]
             [clojure.test :refer :all]))
 
 (def example-matcher {:username string?
@@ -16,12 +17,12 @@
 (deftest basic-matching
   (is (match? example-matcher example-actual)
       "In 'match?', the matcher argument comes first")
-  (is (match? (core/equals-map example-matcher)
+  (is (match? (m/equals-map example-matcher)
               (dissoc example-actual :device))
       "wrapping the matcher in 'equals-map' means the top level of 'actual'
       must have the exact same key/values")
   (is (match? 1 1))
-  (is (match? (core/equals-seq [1 odd?]) [1 3]))
+  (is (match? (m/equals-seq [1 odd?]) [1 3]))
   (is (match? {:a {:b odd?}}
               {:a {:b 1}})
       "Predicates can be used in matchers")


### PR DESCRIPTION
Now, instead of importing `matcher-combinators.core`, which has a lot of extra functions, records, protocols, users who want to use matchers can require `matcher-combinators.matchers`

So midje users would do 
```clojure
(ns ...
  (:require
    [midje.sweet :refer :all]
    [matcher-combinators.matchers :as m]
    [matcher-combinators.midje :refer [match]]))

(fact "sequence matching"
  {:a {:bb 1} :c 2} => (match (m/equals-map {:a {:bb 1} :c 2})))
```

And `clojure.test` users would do
```clojure
(ns ...
  (:require
    [clojure.test :refer :all]
    [matcher-combinators.test] ;; needed for defining `match?` 
    [matcher-combinators.matchers :as m]))

(deftest basic-matching
  (is (match? (m/equals-seq [1 odd?]) [1 3])))
```